### PR TITLE
Automatically adding Header and Footer to each page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -35,7 +35,6 @@ export default function About() {
   ];
   return (
     <>
-      <Header />
       <div className="relative w-full lg:h-85vh">
         <div className="relative isolate h-full overflow-hidden bg-green-500 py-24 sm:py-20">
           <div className="hidden sm:absolute sm:-top-10 sm:right-1/2 sm:-z-10 sm:mr-10 sm:block sm:transform-gpu sm:blur-3xl">
@@ -102,7 +101,6 @@ export default function About() {
             </div>
           </div>
         </div>
-        <Footer />
       </div>
     </>
   );

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -175,7 +175,6 @@ export default function Account() {
 
   return (
     <>
-      <Header />
 
       <main>
         {/* <div className="absolute left-16 top-full -mt-16 transform-gpu opacity-50 blur-3xl xl:left-1/2 xl:-ml-80">

--- a/src/app/addcompany/page.tsx
+++ b/src/app/addcompany/page.tsx
@@ -134,7 +134,6 @@ export default function AddCompany() {
 
   return (
     <main className="bg-app-light flex flex-col items-center justify-start h-full w-full gap-4 ">
-      <Header />
       <div className=" flex p-40">
         <form>
           <div className="space-y-12">

--- a/src/app/companies/page.tsx
+++ b/src/app/companies/page.tsx
@@ -52,9 +52,6 @@ export default function Companies() {
 
   return (
     <main className="bg-app-light flex flex-1 flex-col items-center justify-start h-full w-screen gap-4 min-h-screen">
-      <div>
-        <Header />
-      </div>
 
       <div className="lg:w-500 mt-24">
         {/* <SearchBar

--- a/src/app/donate/page.tsx
+++ b/src/app/donate/page.tsx
@@ -8,7 +8,6 @@ export default function Donate() {
   return (
     <>
       <main className="relative isolate min-h-screen">
-        <Header />
         <img
           src="https://images.unsplash.com/photo-1573322867455-fc97c490c14c?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=3000&q=80"
           alt=""

--- a/src/app/download/page.tsx
+++ b/src/app/download/page.tsx
@@ -12,7 +12,6 @@ export default function Download() {
 
   return (
     <>
-      <Header />
       <div className="w-full min-h-screen flex flex-col justify-end items-center bg-app--light ">
         <div className="h-full w-full md:w-1/2 center flex-col xs:h-900">
           <Image

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { Inter } from "next/font/google";
 import React from "react";
 import { ChakraProvider } from "@chakra-ui/react";
 import { useCompaniesStore } from "@/store/useCompaniesStore";
-
+import LayoutProvider from "@/components/layoutProvider";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
@@ -21,7 +21,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <ChakraProvider>{children}</ChakraProvider>
+        <ChakraProvider>
+          <LayoutProvider>{children}</LayoutProvider>
+        </ChakraProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,12 @@
 // Home Page
 "use client";
 import React from "react";
-import { Header, Hero, Footer } from "@/components/modules";
+import { Hero } from "@/components/modules";
 
 const Home = () => {
   return (
     <main className="app-page-container border min-h-full">
-      <Header />
       <Hero />
-      <Footer />
     </main>
   );
 };

--- a/src/app/submitclaim/[companyId]/page.tsx
+++ b/src/app/submitclaim/[companyId]/page.tsx
@@ -133,7 +133,6 @@ export default function SubmitClaim({ params }: ISubmitClaimProps) {
 
   return (
     <main className="bg-app-light flex flex-col items-center justify-start h-full w-full gap-4">
-      <Header />
       <div className=" flex p-40">
         <form>
           <div className="space-y-12">

--- a/src/app/upcomingfeatures/page.tsx
+++ b/src/app/upcomingfeatures/page.tsx
@@ -78,7 +78,6 @@ export default function UpcomingFeatures() {
 
   return (
     <>
-      <Header />
       <div className="w-full min-h-screen flex flex-col justify-center items-center bg-app--light ">
         <div className="flex divide-y divide-gray-200 overflow-hidden rounded-lg xs:grid xs:gap-px sm:grid sm:gap-px sm:divide-y-0 ">
           {features.map((feature, actionIdx) => (

--- a/src/components/layoutProvider.tsx
+++ b/src/components/layoutProvider.tsx
@@ -1,0 +1,15 @@
+"use client";
+import React from "react";
+import { Footer, Header } from "./modules";
+
+const LayoutProvider = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <>
+      <Header />
+      {children}
+      <Footer />
+    </>
+  );
+};
+
+export default LayoutProvider;

--- a/src/components/layoutProvider.tsx
+++ b/src/components/layoutProvider.tsx
@@ -1,13 +1,17 @@
 "use client";
 import React from "react";
+import { usePathname } from "next/navigation";
 import { Footer, Header } from "./modules";
 
 const LayoutProvider = ({ children }: { children: React.ReactNode }) => {
+  const pathname = usePathname();
+  const specificRoute = "/login";
+  const showComponent = pathname !== specificRoute;
   return (
     <>
-      <Header />
+      {showComponent && <Header />}
       {children}
-      <Footer />
+      {showComponent && <Footer />}
     </>
   );
 };


### PR DESCRIPTION
- Creating LayoutProvider component and adding it to layout file.
- Putting Header and Footer Components inside LayoutProvider
- Deleting Header and Footer components.

note: I have created LayoutProvider instead of adding directly Header and Footer components to layout page to be able to use usePathname hook (hooks work only client-side) .
note: This Provider will be implemented in each page excluding login page.
